### PR TITLE
feat: Leading and trailing edge debounce for the file watch

### DIFF
--- a/lib/dev-middleware.js
+++ b/lib/dev-middleware.js
@@ -3,6 +3,7 @@ let chokidar = require('chokidar');
 let expressws = require('express-ws');
 let fs = require('fs');
 let url = require('url');
+let crypto = require('crypto');
 
 const MIME_TYPES = {
     'mjs': 'application/javascript',
@@ -13,6 +14,7 @@ const MIME_TYPES = {
 module.exports = function (app, config, options) {
     expressws(app);
     let files = {};
+    const fileHashes = {};
     let sockets = [];
 
     if (options.hot) {
@@ -105,28 +107,65 @@ module.exports = function (app, config, options) {
         console.log('\x1b[32m%s\x1b[0m', `Compiled in ${response.stats.time}ms.`);
     }
 
-    async function compiler () {
-        let bundle = await nollup(config);
-        let watcher = chokidar.watch(options.watch);
-        let watcherTimeout;
+    function debounceLeadingAndTrailing(func, wait) {
+        let timeout;
+        let needsCalling = false;
+      
+        return function executedFunction() {
+            let context = this;
+            let args = arguments;
+                
+            let later = function() {
+                timeout = null;
+                if (needsCalling) {
+                    func.apply(context, args)
+                    needsCalling = false;
+                };
+            };
+        
+            let callNow = !timeout;
+            
+            clearTimeout(timeout);
 
-        const onChange = async (path) => {
-            if (fs.lstatSync(path).isFile()) {
-                files = {};
-                bundle.invalidate(path);
-
-                if (watcherTimeout) {
-                    clearTimeout(watcherTimeout);
-                }
-
-                watcherTimeout = setTimeout(async () => {
-                    handleGeneratedBundle(await bundle.generate());
-                }, 100);
+            timeout = setTimeout(later, wait);
+            
+            if (callNow) {
+                func.apply(context, args)
+            } else {
+                needsCalling = true;
             }
         };
+    };
 
-        watcher.on('add', onChange);
-        watcher.on('change', onChange);
+    const onChange = async (path, bundle) => {
+        if (fs.lstatSync(path).isFile()) {
+            // read out the file and generate a hash
+            const file = fs.readFileSync(path);
+            const hash = crypto.createHash('md5').update(file).digest("hex");
+            
+            // if the hash is the same as it was last time, bail and don't recompile
+            if (fileHashes[path] === hash) {
+                return
+            }
+
+            // set the hash so that next time we can bail early
+            fileHashes[path] = hash;
+            
+            files = {};
+            bundle.invalidate(path);
+
+            handleGeneratedBundle(await bundle.generate());
+        }
+    };
+
+    async function compiler () {
+        let bundle = await nollup(config);
+        let watcher = chokidar.watch(options.watch, { ignoreInitial: true });
+
+        const debouncedOnChange = debounceLeadingAndTrailing(path => onChange(path, bundle), 300);
+
+        watcher.on('add', debouncedOnChange);
+        watcher.on('change', debouncedOnChange);
 
         handleGeneratedBundle(await bundle.generate());
     };


### PR DESCRIPTION
This PR removes the 100ms wait before starting compilation of changed files and instead introduces a leading+trailing edge debounce + an md5 hash.

The previous behavior was to wait until the 100ms after the last time the user saved a file, then it would compile.

Now it will immediately compile upon first save, and if the file is saved again it will debounce in a similar manner to previously. It will also hash the file and check if it has changed since the last compile. The debounce has been increased to 300ms.