### PR TITLE
added hmr statuses, statuses events and logging them if "verbose" is passed to the dev-middleware

### DIFF
--- a/examples/scripts/serve.js
+++ b/examples/scripts/serve.js
@@ -6,7 +6,8 @@ let app = express();
 
 app.use(nollupDevServer(app, config, {
     watch: process.cwd() + '/src',
-    hot: true
+    hot: true,
+    verbose: false
 }));
 
 app.use(express.static('./'));

--- a/lib/dev-middleware.js
+++ b/lib/dev-middleware.js
@@ -16,6 +16,21 @@ module.exports = function (app, config, options) {
     let sockets = [];
 
     if (options.hot) {
+        const hotOptions = {
+            verbose: options.verbose
+        }
+
+        nollup.__bundleHooks.add('init',
+            (function () {
+                window.__hot = {
+                    status: 'idle',
+                    options: {hotOptions},
+                    statusHandlers: []
+                };
+            }).toString()
+                .replace('{hotOptions}', JSON.stringify(hotOptions))
+        );
+
         nollup.__bundleHooks.add('module-init', function (instance) {
             instance.hot = {
                 accept: function (callback) {
@@ -24,12 +39,42 @@ module.exports = function (app, config, options) {
 
                 dispose: function (callback) {
                     this._dispose = callback;
+                },
+
+                status: function() {
+                    return window.__hot.status;
+                },
+
+                addStatusHandler: function(callback) {
+                    window.__hot.statusHandlers.push(callback);
+                },
+
+                removeStatusHandler: function(callback) {
+                    const callbackIndex = indow.__hot.statusHandlers.indexOf(callback);
+                    if (callbackIndex > -1) {
+                        window.__hot.statusHandlers.splice(callbackIndex, 1);
+                    }
                 }
             };
         });
 
         nollup.__bundleHooks.add('init', function (modules, instances) {
             var ws = new WebSocket('ws://' + window.location.host + '/__hmr');
+
+            function verboseLog() {
+                if (!window.__hot.options.verbose) {
+                    return;
+                }
+                console.log.apply(console, ['[HMR]'].concat(Array.prototype.slice.call(arguments)));
+            }
+
+            function setHotStatus (status) {
+                verboseLog('Status Change', status);
+                window.__hot.status = status;
+                window.__hot.statusHandlers.forEach(function (handler) {
+                    handler(status);
+                });
+            }
 
             function invalidateParents (id) {
                 return Object.keys(instances).filter(instancesId => {
@@ -41,6 +86,8 @@ module.exports = function (app, config, options) {
             }
 
             function hmrDisposeCallback (id) {
+                setHotStatus('dispose');
+
                 if (instances[id]) {
                     if (instances[id].hot._dispose) {
                         instances[id].hot._dispose();
@@ -49,6 +96,8 @@ module.exports = function (app, config, options) {
             }
 
             function hmrAcceptCallback (id) {
+                setHotStatus('apply');
+
                 if (instances[id]) {
                     instances[id].invalidate = true;
 
@@ -63,17 +112,28 @@ module.exports = function (app, config, options) {
                 }
             }
 
-            ws.onmessage = function (e) {            
+            ws.onmessage = function (e) {
                 let hot = JSON.parse(e.data);
-                
-                hot.changes.forEach(change => {
-                    hmrDisposeCallback(change.id);
 
-                    if (!change.removed) {
-                        modules[change.id] = eval('(' + change.code + ')');
-                        hmrAcceptCallback(change.id);
-                    }
-                });
+                if (hot.status) {
+                    setHotStatus(hot.status);
+                }
+
+                if (hot.changes) {
+                    verboseLog('Changes Received');
+
+                    hot.changes.forEach(change => {
+                        hmrDisposeCallback(change.id);
+
+                        if (!change.removed) {
+                            modules[change.id] = eval('(' + change.code + ')');
+
+                            hmrAcceptCallback(change.id);
+                        }
+                    });
+
+                    setHotStatus('idle');
+                }
             };
         });
 
@@ -86,21 +146,27 @@ module.exports = function (app, config, options) {
         });
     }
 
+    function messageAllSocketsInHotMode (message) {
+        if (!options.hot) {
+            return;
+        }
+
+        sockets.forEach(socket => {
+            socket.send(JSON.stringify(message));
+        });
+    }
+
     function handleGeneratedBundle (response) {
         if (config.experimentalCodeSplitting) {
             let output = response.output;
             Object.keys(output).forEach(file => {
-                files[file] = typeof output[file] === 'string'? output[file] : output[file].code;
+                files[file] = typeof output[file] === 'string' ? output[file] : output[file].code;
             });
         } else {
             files[config.output.file] = response.code;
         }
-        
-        if (options.hot) {
-            sockets.forEach(socket => {
-                socket.send(JSON.stringify({ changes: response.changes }));
-            });
-        }
+
+        messageAllSocketsInHotMode({ changes: response.changes });
 
         console.log('\x1b[32m%s\x1b[0m', `Compiled in ${response.stats.time}ms.`);
     }
@@ -111,6 +177,8 @@ module.exports = function (app, config, options) {
         let watcherTimeout;
 
         const onChange = async (path) => {
+            messageAllSocketsInHotMode({ status: 'check' });
+
             if (fs.lstatSync(path).isFile()) {
                 files = {};
                 bundle.invalidate(path);
@@ -120,7 +188,10 @@ module.exports = function (app, config, options) {
                 }
 
                 watcherTimeout = setTimeout(async () => {
-                    handleGeneratedBundle(await bundle.generate());
+                    messageAllSocketsInHotMode({ status: 'prepare' });
+                    const update = await bundle.generate();
+                    messageAllSocketsInHotMode({ status: 'ready' });
+                    handleGeneratedBundle(update);
                 }, 100);
             }
         };


### PR DESCRIPTION
mimicked the statuses from webpack:
https://webpack.js.org/api/hot-module-replacement/#status