### PR TITLE
Resolve mime types using mime-types package

### DIFF
--- a/lib/dev-middleware.js
+++ b/lib/dev-middleware.js
@@ -4,14 +4,7 @@ let expressws = require('express-ws');
 let fs = require('fs');
 let url = require('url');
 let hmr = require('./plugin-hmr');
-
-const MIME_TYPES = {
-    'mjs': 'application/javascript',
-    'js': 'application/javascript',
-    'css': 'text/css',
-    'json': 'application/json',
-    'svg': 'image/svg+xml'
-};
+let mime = require('mime-types');
 
 module.exports = function (app, config, options) {
     expressws(app);
@@ -113,9 +106,12 @@ module.exports = function (app, config, options) {
 
             let filename = url.parse(req.url).pathname.replace('/', '');
             if (files[filename]) {
-                res.writeHead(200, {
-                    'Content-Type': MIME_TYPES[filename.substring(filename.lastIndexOf('.') + 1)]
-                });
+                const type = mime.lookup(filename);
+                if (type) {
+                    res.writeHead(200, { 'Content-Type': type });
+                } else {
+                    res.writeHead(200);
+                }
 
                 res.write(files[filename]);
                 res.end();

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express-http-proxy": "^1.5.1",
     "express-ws": "^4.0.0",
     "magic-string": "^0.24.0",
+    "mime-types": "^2.1.24",
     "source-map": "^0.5.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds support to all mime types known to apache. The mime.types file was copied from my system's /etc/mime.types.

It also changes the writeHead portion to not include content-type header if file extension is unknown.
