### PR TITLE
Greeting message

### DIFF
--- a/lib/dev-middleware.js
+++ b/lib/dev-middleware.js
@@ -23,6 +23,9 @@ module.exports = function (app, config, options) {
         app.ws('/__hmr', (ws, req) => {
             sockets.push(ws);
 
+            // greeting -- see: https://github.com/PepsRyuu/nollup/issues/35
+            ws.send(JSON.stringify({ greeting: true }))
+
             ws.on('close', () => {
                 sockets.splice(sockets.indexOf(ws), 1);
             });

--- a/lib/dev-middleware.js
+++ b/lib/dev-middleware.js
@@ -56,7 +56,7 @@ module.exports = function (app, config, options) {
         let bundle = await nollup(config);
         let watcher = chokidar.watch(options.watch || process.cwd(), {
             ignored:  ['**/node_modules/**/*', '**/.git/**/*'],
-        });       
+        });
 
         let watcherTimeout;
 
@@ -92,7 +92,7 @@ module.exports = function (app, config, options) {
         } catch (e) {
             console.log('\x1b[91m%s\x1b[0m', e);
         }
-        
+
     };
 
     compiler();

--- a/lib/plugin-hmr.js
+++ b/lib/plugin-hmr.js
@@ -65,6 +65,10 @@ module.exports = function (options) {
                 ws.onmessage = function (e) {
                     var hot = JSON.parse(e.data);
 
+                    if (hot.greeting) {
+                      verboseLog('Enabled');
+                    }
+
                     if (hot.status) {
                         setHotStatus(hot.status);
                     }


### PR DESCRIPTION
As discussed in #35, here's a greeting console message.

I wondered whether this should be a "Status idle" message, because it is semantically correct, but in the end I think a 100% unambiguous "Enabled" (inspired from Webpack) can be better in some cases. Like for example my test pilot that waits specifically for init, and could be misled if it caught a subsequent "Status idle" (this would probably mean there's an error in my code, but better to know it anyway).