### PR TITLE
Make resolve async to align with Rollup API

### DIFF
--- a/lib/impl/PluginContext.js
+++ b/lib/impl/PluginContext.js
@@ -57,7 +57,7 @@ module.exports = {
                 console.warn('getModuleInfo: not implemented');
             },
 
-            resolve () {
+            async resolve () {
                 console.warn('resolve: not implemented');
             },
 

--- a/test/cases/api/context.js
+++ b/test/cases/api/context.js
@@ -144,6 +144,25 @@ describe ('API: Plugin Context', () => {
         });
     });
 
+    describe ('resolve', () => {
+        it ('should return a promise', async () => {
+            fs.stub('./src/main.js', () => 'export default 123');
+
+            let bundle = await nollup({
+                input: './src/main.js',
+                plugins: [{
+                    transform () {
+                        const result = this.resolve('./foo', '/bar')
+                        expect(result).to.be.an.instanceof(Promise)
+                    }
+                }]
+            });
+
+            let { output } = await bundle.generate({ format: 'esm' });
+            fs.reset();
+        })
+    })
+
     describe ('warn', () => {
         it ('should output warning message');
     });


### PR DESCRIPTION
Plugin context's `resolve` should return a promise to align with [Rollup API](https://rollupjs.org/guide/en/#plugin-context):

> this.resolve(source: string, importer: string, options?: {skipSelf: boolean}) => Promise<{id: string, external: boolean} | null>

As it currently doesn't, it breaks `rollup-plugin-commonjs` (at [this line](https://github.com/rollup/rollup-plugin-commonjs/blob/master/src/resolve-id.js#L54)) when a file isn't resolve before it. The file could still be resolved by a plugin after it, so it's worth preventing the crash.