### PR TITLE
Use secure websockets when needed

### DIFF
--- a/lib/plugin-hmr.js
+++ b/lib/plugin-hmr.js
@@ -16,7 +16,8 @@ module.exports = function (options = { bundleId: '' }) {
                 var ws;
 
                 if (typeof WebSocket === 'function') {
-                    ws = new WebSocket('ws://' + ${options.hmrHost? `"${options.hmrHost}"` : '__nollup__global__.location.host'} + '/__hmr${bundleId}');
+                    var protocol =  __nollup__global__.location.protocol === 'https:' ? 'wss://' : 'ws://';
+                    ws = new WebSocket(protocol + ${options.hmrHost? `"${options.hmrHost}"` : '__nollup__global__.location.host'} + '/__hmr${bundleId}');
                 }
 
                 function verboseLog() {


### PR DESCRIPTION
If you're loading the server over `https://` it tries to make a websocket connection over `ws://`, which isn't allowed. This is just a quick fix to check for the current protocol and use `ws://` or `wss://` accordingly.