### PR TITLE
upgrade to chokidar 3

### DIFF
--- a/lib/dev-middleware.js
+++ b/lib/dev-middleware.js
@@ -143,6 +143,7 @@ module.exports = function (app, config, options) {
         let filter = createFilter(watchInclude, watchExclude);
 
         let watcher = chokidar.watch(options.watch || process.cwd(), {
+            ignoreInitial: true,
             // Using a function improves performance when using symlink package managers - Issue #63
             ignored: path => {
                 if (watchExclude.length > 0 || watchInclude.length > 0) {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@rollup/pluginutils": "^3.0.8",
     "acorn": "^7.0.0",
-    "chokidar": "^2.0.2",
+    "chokidar": "^3.0.0",
     "convert-source-map": "^1.5.1",
     "express": "^4.16.3",
     "express-history-api-fallback": "^2.2.1",


### PR DESCRIPTION
It's worth it because they shoved [90% of the package size](https://packagephobia.now.sh/result?p=chokidar) in v3, and drastically reduce the number of deps, which is always good to take. Plus it has overall better performance apparently (here's the [article](https://paulmillr.com/posts/chokidar-3-save-32tb-of-traffic/) they published for the release, if you're interested).

I also turned the `ignoreInitial` option to `true`, because I think we don't need those events. Everything seems to work OK with it in my tests. It also removes the multiple `Compiled in ...` messages that I sometime gets on start:

~~~
Compiled in 4500ms.
Compiled in 44ms.
Compiled in 46ms.
Compiled in 51ms.
~~~

(That's the 500 files test project -- 4.5s is darn good!)