### PR TITLE
Fix dynamic imports missing deps

### DIFF
--- a/examples/example-globals/rollup.config.js
+++ b/examples/example-globals/rollup.config.js
@@ -5,8 +5,9 @@ export default {
         format: 'iife',
         globals: {
             'jquery': '$',
-            'maths': 'Math'
+            'maths': 'Math',
+            'underscore': '_'
         }
     },
-    external: ['jquery', 'maths', 'underscore', 'browser-document', 'location']
+    external: ['jquery', 'maths', 'underscore', 'document', 'location']
 }

--- a/examples/example-globals/src/main.js
+++ b/examples/example-globals/src/main.js
@@ -1,7 +1,7 @@
 import jquery from 'jquery';
 import _ from 'underscore';
 import { max } from 'maths';
-import document, { querySelector } from 'browser-document';
+import document, { querySelector } from 'document';
 import { pathname } from 'location';
 
 jquery('body').text('Hello World');

--- a/examples/example-react-hot-loader/package.json
+++ b/examples/example-react-hot-loader/package.json
@@ -16,7 +16,7 @@
         "rollup": "^1.28.0",
         "rollup-plugin-babel": "^4.3.3",
         "rollup-plugin-commonjs-alternate": "^0.1.0",
-        "rollup-plugin-hot-css": "0.0.6",
+        "rollup-plugin-hot-css": "^0.2.1",
         "rollup-plugin-node-resolve": "^5.2.0",
         "rollup-plugin-replace": "^2.2.0",
         "rollup-plugin-static-files": "0.0.1",

--- a/examples/example-react-hot-loader/rollup.config.js
+++ b/examples/example-react-hot-loader/rollup.config.js
@@ -20,7 +20,7 @@ let config = {
         }),
         hotcss({
             hot: process.env.NODE_ENV === 'development',
-            filename: 'styles.css'
+            file: 'styles.css'
         }),
         babel(),
         node_resolve(),

--- a/lib/impl/ImportExportResolver.js
+++ b/lib/impl/ImportExportResolver.js
@@ -12,173 +12,22 @@ let AcornParser = require('./AcornParser');
 let PluginLifecycle = require('./PluginLifecycle');
 let { isExternal } = require('./utils');
 
-async function resolveImport (context, input, output, node, currentpath) {
-    if (isExternal(context, node.source.value)) {
-        return resolveExternalImport(context, input, output, node);
-    } else {
-        return resolveInternalImport(context, input, output, node, currentpath);
-    }
+/**
+ * Setting imports to empty can cause source maps to break.
+ * This is because some imports could span across multiple lines when importing named exports.
+ * To bypass this problem, this function will replace all text except line breaks with spaces.
+ * This will preserve the lines so source maps function correctly.
+ * Source maps are ideally the better way to solve this, but trying to maintain performance.
+ *
+ * @method blanker
+ */
+function blanker (input, start, end) {
+    return input.substring(start, end).replace(/[^\n\r]/g, ' ');
 }
 
-function getExternalSpecifiers (node) {
-    let externalDependencies = [];
-
-    if (node.specifiers && node.specifiers.length > 0) {
-        node.specifiers.forEach(node => {
-            if (node.type === 'ImportDefaultSpecifier') {
-                externalDependencies.push('default');
-            }
-
-            if (node.type === 'ImportSpecifier') {
-                externalDependencies.push(node.imported.name);
-            }
-
-            if (node.type === 'ImportNamespaceSpecifier') {
-                externalDependencies.push('*');
-            }
-
-            if (node.type === 'ExportSpecifier') {
-                externalDependencies.push(node.local.name);
-            }
-        });
-    }
-
-    return externalDependencies;
-}
-
-function resolveExternalImport (context, input, output, node) {
-    let transpiled = '', importee = '', defaultNode, globalName;
-    let globalConf = (context.output && context.output.globals) || {};
-
-    output.externalDependencies[node.source.value] = getExternalSpecifiers(node);
-
-    if ((node.specifiers && node.specifiers.length > 0) || node.type === 'ExportAllDeclaration') {
-        defaultNode = node.specifiers && node.specifiers.filter(n => n.type === 'ImportDefaultSpecifier')[0];
-
-        // Need to figure out global name.
-        // First use the configuration, else use the default name, else the source value.
-        globalName = (
-            globalConf[node.source.value] || 
-            (defaultNode && defaultNode.local.name) || 
-            node.source.value.replace(/[\W]/g, '_')
-        );
-
-        importee = '_e' + globalName;
-
-        if (context.output && context.output.format === 'cjs') {
-            transpiled += `var ${importee} = require("${node.source.value}");`;
-        } else if (context.output && context.output.format === 'esm') {
-            if (node.type === 'ExportAllDeclaration') {
-                transpiled += `var ${importee} = __nollup__external__${node.source.value.replace(/[\W]/g, '_')}__;`;
-            }
-        } else {
-            transpiled += `var ${importee} = __nollup__global__.${globalName};`
-        }
-    }
-
-    if (context.output && context.output.format !== 'esm' && node.specifiers && node.specifiers.length > 0) {
-        node.specifiers.forEach(node => {
-            if (node.type === 'ImportDefaultSpecifier') {
-                transpiled += `var ${node.local.name} = ${importee} && ${importee}.hasOwnProperty("default")? ${importee}.default : ${importee};`;
-            }
-
-            if (node.type === 'ImportSpecifier') {
-                transpiled += `var ${node.local.name} = ${importee}.${node.imported.name};`;
-            }
-
-            if (node.type === 'ImportNamespaceSpecifier') {
-                transpiled += `var ${node.local.name} = ${importee}`;
-            }
-
-            if (node.type === 'ExportSpecifier') {
-                transpiled += `var ex_${node.exported.name} = ${importee}.${node.local.name};`;
-            }
-        });
-    }
-
-    if (context.output && context.output.format === 'esm' && node.specifiers && node.specifiers.length > 0) {
-        let importee = node.source.value.replace(/[\W]/g, '_');
-
-        node.specifiers.forEach(node => {
-            if (node.type === 'ImportDefaultSpecifier') {
-                transpiled += `var ${node.local.name} = __nollup__external__${importee}__default__;`;
-            }
-
-            if (node.type === 'ImportSpecifier') {
-                transpiled += `var ${node.local.name} = __nollup__external__${importee}__${node.imported.name}__;`;
-            }
-
-            if (node.type === 'ImportNamespaceSpecifier') {
-                transpiled += `var ${node.local.name} = __nollup__external__${importee}__;`;
-            }
-
-            if (node.type === 'ExportSpecifier') {
-                transpiled += `var ex_${node.exported.name} = __nollup__external__${importee}__${node.local.name}__;`;
-            }
-        });
-    }
-
-    output.transpiled.overwrite(node.start, node.end, transpiled);
-    return importee;
-}
-
-async function resolveInternalImport (context, input, output, node, currentpath) {
-    let dependency_path = await PluginLifecycle.resolveId(context, node.source.value, currentpath);
-
-    if (dependency_path === false || (typeof dependency_path === 'object' && dependency_path.external)) {
-        output.externalDependencies[dependency_path.id || node.source.value] = getExternalSpecifiers(node);
-        return;
-    }
-
-    let importee = `_i${output.dependencies.length}`;
-    output.dependencies.push(dependency_path.id);
-
-    if (node.specifiers && node.specifiers.length === 0) {
-        output.imports.push({
-            importee
-        });
-    }
-
-    if (node.specifiers && node.specifiers.length > 0) {
-        node.specifiers.forEach(specifier => {
-            if (specifier.type === 'ImportDefaultSpecifier') {
-                output.imports.push({
-                    local: specifier.local.name,
-                    imported: 'default',
-                    importee
-                });
-            }
-
-            if (specifier.type === 'ImportSpecifier') {
-                output.imports.push({
-                    local: specifier.local.name,
-                    imported: specifier.imported.name,
-                    importee
-                });
-            }
-
-            if (specifier.type === 'ImportNamespaceSpecifier') {
-                output.imports.push({
-                    local: specifier.local.name,
-                    importee,
-                    imported: '*'
-                });
-            }
-
-            if (specifier.type === 'ExportSpecifier') {
-                output.imports.push({
-                    local: 'ex_' + specifier.exported.name,
-                    importee,
-                    imported: specifier.local.name
-                });
-            }
-        });
-    }
-
-    output.transpiled.overwrite(node.start, node.end, '');
-    return importee;
-}
-
+/**
+ * @method resolveDefaultExport
+ */
 function resolveDefaultExport (context, input, output, node) {
     if (node.declaration && node.declaration.id) {
         // Using + 15 to avoid "export default (() => {})" being converted
@@ -194,6 +43,9 @@ function resolveDefaultExport (context, input, output, node) {
     output.exports.push('default');
 }
 
+/**
+ * @method resolveNamedExport
+ */
 async function resolveNamedExport (context, input, output, node, currentpath) {
     // export function / class / let...
     if (node.declaration) {
@@ -220,71 +72,59 @@ async function resolveNamedExport (context, input, output, node, currentpath) {
 
     // export { specifier, specifier }
     if (node.specifiers.length > 0) {
-        let importee, transpiled = '';
+        let transpiled = '';
 
         // export { imported } from './file.js';
         if (node.source) {
-            importee = await resolveImport(context, input, output, node, currentpath);
+            await resolveImport(context, input, output, node, currentpath);
         }
 
-        node.specifiers.forEach(node => {
-            if (node.type === 'ExportSpecifier') {
-                if (importee) {
-                    transpiled += `__e__('${node.exported.name}', ex_${node.exported.name});`;
+        node.specifiers.forEach(spec => {
+            if (spec.type === 'ExportSpecifier') {
+                if (node.source) {
+                    transpiled += `__e__('${spec.exported.name}', ex_${spec.exported.name});`;
                 } else {
-                    transpiled += `__e__('${node.exported.name}', ${node.local.name});`;
+                    transpiled += `__e__('${spec.exported.name}', ${spec.local.name});`;
                 }
-                output.exports.push(node.exported.name);
+                output.exports.push(spec.exported.name);
             }
         });
 
-        if (importee) {
-            output.transpiled.appendRight(node.end, transpiled);
-        } else {
-            output.transpiled.overwrite(node.start, node.end, transpiled);
+        if (!node.source) {
+            // Export from statements are already blanked by the import section.
+            output.transpiled.overwrite(node.start, node.end, blanker(input, node.start, node.end));
         }
-        
+
+        output.transpiled.appendRight(node.end, transpiled);
     }
 }
 
+/**
+ * @method resolveAllExport
+ */
 async function resolveAllExport (context, input, output, node, currentpath) {
     // export * from './file';
-    let importee = await resolveImport(context, input, output, node, currentpath);
-    if (!importee) {
+    let dep = await resolveImport(context, input, output, node, currentpath);
+    if (!dep) {
         return;
     }
 
-    output.imports.push({
-        importee,
+    dep.specifiers.push({
+        local: 'ex' + dep.importee,
         imported: '*'
     });
 
-    let transpiled = `for(var __k__ in ex${importee}){__k__ !== "default" && (__e__(__k__, ex${importee}[__k__]))}`;
+    let transpiled = `for(var __k__ in ex${dep.importee}){__k__ !== "default" && (__e__(__k__, ex${dep.importee}[__k__]))}`;
     output.transpiled.appendRight(node.end, transpiled);
 }
 
-async function resolveDynamicImport (context, input, output, node, currentpath) {    
-    let arg = node.source;
-    let value = arg.type === 'Literal'? arg.value : arg;
 
-    let dependency_path = await PluginLifecycle.resolveDynamicImport(context, value, currentpath);
-
-    if (dependency_path === false || (typeof dependency_path === 'object' && dependency_path.external)) {
-        output.dynamicExternalDependencies.push(dependency_path.id || value);
-        return;
-    }
-
-    let index = output.dynamicDependencies.length;
-
-    // import('hello') --> require.dynamic(__nollup__dynamic__0);
-    output.transpiled.overwrite(node.start, node.start + 6, 'require.dynamic');
-    output.transpiled.overwrite(arg.start, arg.end, '__nollup__dynamic__' + index);
-
-    // Either a string or a ESNode can be pushed here. Let resolveDynamicImport
-    // determine how to resolve the file.
-    output.dynamicDependencies.push(dependency_path.id);
-}
-
+/**
+ * Convert URL meta properties if they exist.
+ * Otherwise, run the resolveImportMeta hook.
+ *
+ * @method resolveMetaProperty
+ */
 const META_PROPS = ['ROLLUP_FILE_URL_', 'ROLLUP_ASSET_URL_', 'ROLLUP_CHUNK_URL_'];
 function resolveMetaProperty (context, input, output, node, currentpath) {
     if (node.meta_property) {
@@ -310,15 +150,99 @@ function resolveMetaProperty (context, input, output, node, currentpath) {
     }
 }
 
+/**
+ * @method resolveDynamicImport
+ */
+async function resolveDynamicImport (context, input, output, node, currentpath) {    
+    let arg = node.source;
+    let value = arg.type === 'Literal'? arg.value : arg;
+    let resolved = await PluginLifecycle.resolveDynamicImport(context, value, currentpath);
+
+    if (resolved === false || (typeof resolved === 'object' && resolved.external)) {
+        output.externalDynamicImports.push(resolved.id || value);
+        return;
+    }
+
+    let index = output.dynamicImports.length;
+
+    // import('hello') --> require.dynamic(__nollup__dynamic__0);
+    output.transpiled.overwrite(node.start, node.start + 6, 'require.dynamic');
+    output.transpiled.overwrite(arg.start, arg.end, '__nollup__dynamic__' + index);
+
+    // Either a string or a ESNode can be pushed here. Let resolveDynamicImport
+    // determine how to resolve the file.
+    output.dynamicImports.push(resolved.id);
+}
+
+
+/**
+ * @method resolveImport
+ */
+async function resolveImport (context, input, output, node, currentpath) {
+    let resolved = await PluginLifecycle.resolveId(context, node.source.value, currentpath);
+
+    let dependency = {
+        source: undefined,
+        specifiers: []
+    };
+
+    if (isExternal(context, node.source.value) || resolved === false || (typeof resolved === 'object' && resolved.external)) {
+        dependency.importee = `__nollup__external__${node.source.value.replace(/[\W]/g, '_')}__`;
+        dependency.source = node.source.value;
+        output.externalImports.push(dependency);
+    } else {
+        dependency.importee = `_i${output.imports.length}`;
+        dependency.source = resolved.id;
+        output.imports.push(dependency);
+    }
+
+    if (node.specifiers && node.specifiers.length > 0) {
+        node.specifiers.forEach(specifier => {
+            if (specifier.type === 'ImportDefaultSpecifier') {
+                dependency.specifiers.push({
+                    local: specifier.local.name,
+                    imported: 'default'
+                });
+            }
+
+            if (specifier.type === 'ImportSpecifier') {
+                dependency.specifiers.push({
+                    local: specifier.local.name,
+                    imported: specifier.imported.name
+                });
+            }
+
+            if (specifier.type === 'ImportNamespaceSpecifier') {
+                dependency.specifiers.push({
+                    local: specifier.local.name,
+                    imported: '*'
+                });
+            }
+
+            if (specifier.type === 'ExportSpecifier') {
+                dependency.specifiers.push({
+                    local: 'ex_' + specifier.exported.name,
+                    imported: specifier.local.name
+                });
+            }
+        });
+    }
+
+    output.transpiled.overwrite(node.start, node.end, blanker(input, node.start, node.end));
+    return dependency;
+}
+
+/**
+ * @method ImportExportResolver
+ */
 module.exports = async function (input, context, currentpath) {
     let output = {
         transpiled: new MagicString(input),
-        dependencies: [],
-        dynamicDependencies: [],
-        externalDependencies: {},
-        dynamicExternalDependencies: [],
         imports: [],
-        exports: []
+        externalImports: [],
+        exports: [],
+        dynamicImports: [],
+        externalDynamicImports: []
     };
 
     let ast = AcornParser.parse(input);
@@ -365,13 +289,8 @@ module.exports = async function (input, context, currentpath) {
 
     await walk(ast.body);
 
-    return { 
-        transpiled: output.transpiled.toString(), 
-        dependencies: output.dependencies, 
-        dynamicDependencies: output.dynamicDependencies,
-        externalDependencies: output.externalDependencies,
-        dynamicExternalDependencies: output.dynamicExternalDependencies,
-        imports: output.imports,
-        exports: output.exports
-    };
+    output.map = output.transpiled.generateMap({ source: currentpath });
+    output.transpiled = output.transpiled.toString();
+
+    return output;
 }

--- a/lib/impl/NollupContext.js
+++ b/lib/impl/NollupContext.js
@@ -47,11 +47,7 @@ module.exports = {
         if (!options.output) {
             options.output = {};
         }
-
-        if (!options.output.format) {
-            options.output.format = 'esm';
-        }
-
+        
         options.plugins.forEach(plugin => {
             if (plugin.options) {
                 options = plugin.options.call({
@@ -73,7 +69,7 @@ module.exports = {
             bundle: {},
             watchFiles: {},
             externalFiles: {},
-            dynamicExternalFiles: {},
+            externalDynamicFiles: {},
             pluginsContext: []
         };
 
@@ -92,6 +88,8 @@ module.exports = {
         output.assetFileNames = output.assetFileNames || 'assets/[name]-[hash][extname]';
         output.chunkFileNames = output.chunkFileNames || '[name]-[hash].js';
         output.entryFileNames = output.entryFileNames || '[name].js';
+        output.format = output.format || 'esm';
+        output.globals = output.globals || {};
         context.output = output;
     }
 }

--- a/lib/impl/ParseError.js
+++ b/lib/impl/ParseError.js
@@ -4,7 +4,7 @@ module.exports = class ParseError extends Error {
             throw parent_error;
         }
 
-        let filename = file.replace(process.cwd(), '').substring(1);
+        let filename = file.replace(process.cwd(), '');
         let details = parent_error instanceof TypeError? parent_error.stack : parent_error;
         let message = filename + '\n' + details;
         super(message);

--- a/lib/impl/PluginContext.js
+++ b/lib/impl/PluginContext.js
@@ -90,11 +90,11 @@ module.exports = {
                         id: id,
                         isEntry: file.isEntry,
                         isExternal: false,
-                        importedIds: Object.keys(file.externalDependencies).concat(file.dependencies)
+                        importedIds: file.externalImports.map(i => i.source).concat(file.imports.map(i => i.source))
                     };
                 }
 
-                let externalFile = context.externalFiles[id] || context.dynamicExternalFiles[id];
+                let externalFile = context.externalFiles[id] || context.externalDynamicFiles[id];
                 if (externalFile) {
                     return {
                         id: id,

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ let { formatFileName, resolvePath } = require('./impl/utils');
  * @param {String} current
  * @return {Promise}
  */
-async function parse (context, filepath, current, level, isEntry, input_modules) { 
+async function parse (context, filepath, current, level, isEntry, input_modules) {
     if (level >= 255) {
         throw new Error('Maximum parse call stack exceeded.');
     }
@@ -49,9 +49,9 @@ async function parse (context, filepath, current, level, isEntry, input_modules)
             PluginLifecycle.setCurrentFile(context, filepath);
             let loaded = await PluginLifecycle.load(context, filepath, current);
             let transformed = await PluginLifecycle.transform(context, loaded.code, filepath);
-            let { 
-                transpiled, 
-                exports, 
+            let {
+                transpiled,
+                exports,
                 imports,
                 externalImports,
                 dynamicImports,
@@ -97,8 +97,8 @@ async function parse (context, filepath, current, level, isEntry, input_modules)
 
                 context.references[dep.source]++;
             });
-        }    
-        
+        }
+
         input_modules[filepath] = true;
 
         // Circular Dependency Check
@@ -115,7 +115,7 @@ async function parse (context, filepath, current, level, isEntry, input_modules)
                 await parse(context, imports[i].source, filepath, level + 1, false, input_modules);
             } catch (e) {
                 throw new ParseError(imports[i].source, e);
-            } 
+            }
         }
 
         let dynamicImports = file.dynamicImports;
@@ -161,7 +161,7 @@ function createFileFunctionWrapper (context, filepath) {
 
         return `'./${formatFileName(context, dependency, context.output.chunkFileNames)}'`;
     });
-    
+
     // Turning the code into eval statements, so we need
     // to escape line breaks and quotes. Using a multiline
     // approach here so that the compiled code is still
@@ -207,7 +207,7 @@ function createFileFunctionWrapper (context, filepath) {
             }, function (require, module, __nollup__global__) {
                 "use strict";
                 eval('${code}');
-                ${syntheticNamedExports? 
+                ${syntheticNamedExports?
                     `if (module.exports.default) {
                         for (var prop in module.exports.default) {
                             prop !== 'default' && __e__(prop, module.exports.default[prop]);
@@ -219,7 +219,7 @@ function createFileFunctionWrapper (context, filepath) {
             ${imports.map(i => {
                 return `${i.importee} = __c__(${context.files[i.source].module_id}) && function () { return __r__(${context.files[i.source].module_id}) }`;
             }).join('; ')}
-        }   
+        }
     `.trim();
 }
 
@@ -233,9 +233,9 @@ function createExternalImports (context) {
 
         // Bare external import
         if (specifiers.length === 0) {
-            if (format === 'esm') 
+            if (format === 'esm')
                 return `import '${file}';`
-            if (format === 'cjs') 
+            if (format === 'cjs')
                 return `require('${file}');`
         }
 
@@ -243,28 +243,28 @@ function createExternalImports (context) {
             let iifeName = globals[file] || name;
 
             if (s === '*') {
-                if (format === 'esm') 
+                if (format === 'esm')
                     return `import * as __nollup__external__${name}__ from '${file}';`;
-                if (format === 'cjs') 
+                if (format === 'cjs')
                     return `var __nollup__external__${name}__ = require('${file}');`;
-                if (format === 'iife') 
+                if (format === 'iife')
                     return `var __nollup__external__${name}__ = self.${iifeName};`
             }
 
             if (s === 'default') {
-                if (format === 'esm') 
+                if (format === 'esm')
                     return `import __nollup__external__${name}__default__ from '${file}';`;
-                if (format === 'cjs') 
+                if (format === 'cjs')
                     return `var __nollup__external__${name}__default__ = require('${file}').hasOwnProperty('default')? require('${file}').default : require('${file}');`
-                if (format === 'iife') 
+                if (format === 'iife')
                     return `var __nollup__external__${name}__default__ = self.${iifeName} && self.${iifeName}.hasOwnProperty('default')? self.${iifeName}.default : self.${iifeName};`
             }
 
-            if (format === 'esm') 
+            if (format === 'esm')
                 return `import { ${s} as __nollup__external__${name}__${s}__ } from '${file}';`;
-            if (format === 'cjs') 
+            if (format === 'cjs')
                 return `var __nollup__external__${name}__${s}__ = require('${file}').${s};`
-            if (format === 'iife') 
+            if (format === 'iife')
                 return `var __nollup__external__${name}__${s}__ = self.${iifeName}.${s};`
         }).join('\n');
     }).join('\n');
@@ -273,7 +273,7 @@ function createExternalImports (context) {
 }
 
 /**
- * Generates code. 
+ * Generates code.
  *
  * @method generate
  * @param {Context}
@@ -287,7 +287,7 @@ async function generate (context, input, dynamicFileName) {
 
     let files = Object.keys(input.modules).map(filepath => {
         return context.files[filepath].module_id + ':' + createFileFunctionWrapper(context, filepath);
-    });  
+    });
 
     if (dynamicFileName) {
         return `
@@ -341,7 +341,7 @@ async function generate (context, input, dynamicFileName) {
                     module.__impl = impl;
                 }, function (bindingName, bindingValue) {
                     module.exports[bindingName] = bindingValue;
-                
+
                     Object.keys(instances).forEach(key => {
                         if (instances[key].dependencies.indexOf(number) > -1) {
                             instances[key].__binder();
@@ -444,7 +444,7 @@ async function generate (context, input, dynamicFileName) {
 
                 // Make sure module wasn't resolved as a result of circular dep.
                 if (!module.__resolved) {
-                    executeModuleImpl(module);                  
+                    executeModuleImpl(module);
                 }
             };
 
@@ -495,7 +495,7 @@ async function generate (context, input, dynamicFileName) {
 
         ${context.output.format === 'esm'? context.files[input.file].exports.map(declaration => {
             if (declaration === 'default') {
-                return 'export default __nollup_entry_exports.default;' 
+                return 'export default __nollup_entry_exports.default;'
             } else {
                 return `export var ${declaration} = __nollup_entry_exports.${declaration};`
             }
@@ -531,20 +531,20 @@ async function bundle (context) {
     let buildFinish = async (arg) => {
         for (let i = 0; i < context.plugins.length; i++) {
             await PluginLifecycle.callPluginMethod(
-                context.pluginsContext[i], 
-                context.plugins[i], 
+                context.pluginsContext[i],
+                context.plugins[i],
                 'buildEnd',
                 arg
             );
         }
     };
-    
+
     try {
         for (let i = 0; i < context.plugins.length; i++) {
             await PluginLifecycle.callPluginMethod(
                 context.pluginsContext[i],
-                context.plugins[i], 
-                'buildStart', 
+                context.plugins[i],
+                'buildStart',
                 context.options
             );
         }
@@ -557,7 +557,7 @@ async function bundle (context) {
     } catch (e) {
         await buildFinish(e);
         throw new ParseError(PluginLifecycle.getCurrentChunk(context) || '', e);
-    }    
+    }
 
     await buildFinish();
 
@@ -628,7 +628,7 @@ async function bundle (context) {
                 imports: [],
                 exports: context.files[input.file].exports
             };
-        } 
+        }
     }
 
     for (let key in context.dynamicDependencies) {
@@ -652,8 +652,8 @@ async function bundle (context) {
         for (let i = 0; i < context.plugins.length; i++) {
             await PluginLifecycle.callPluginMethod(
                 context.pluginsContext[i],
-                context.plugins[i], 
-                'renderStart', 
+                context.plugins[i],
+                'renderStart',
                 context.output,
                 context.options
             );
@@ -665,8 +665,8 @@ async function bundle (context) {
                 for (let i = 0; i < context.plugins.length; i++) {
                     let result = await PluginLifecycle.callPluginMethod(
                         context.pluginsContext[i],
-                        context.plugins[i], 
-                        'renderChunk', 
+                        context.plugins[i],
+                        'renderChunk',
                         file.code,
                         file,
                         context.output
@@ -688,28 +688,28 @@ async function bundle (context) {
     } catch (e) {
         for (let i = 0; i < context.plugins.length; i++) {
             await PluginLifecycle.callPluginMethod(
-                context.pluginsContext[i], 
-                context.plugins[i], 
-                'renderError', 
+                context.pluginsContext[i],
+                context.plugins[i],
+                'renderError',
                 e
             );
         }
     }
-    
+
 
     for (let i = 0; i < context.plugins.length; i++) {
         await PluginLifecycle.callPluginMethod(
-            context.pluginsContext[i], 
-            context.plugins[i], 
-            'generateBundle', 
-            context.output, 
+            context.pluginsContext[i],
+            context.plugins[i],
+            'generateBundle',
+            context.output,
             context.bundle
         );
     }
 
     let props = {
         stats: {
-            time: Date.now() - start 
+            time: Date.now() - start
         },
         changes: new_modules.concat(changed_modules).concat(removed_modules),
         output: Object.keys(context.bundle).map(fileName => context.bundle[fileName])
@@ -788,7 +788,7 @@ async function nollup (options) {
                 }
             });
         }
-    }    
+    }
 }
 
 module.exports = nollup;

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,11 +31,11 @@ async function parse (context, filepath, current, level, isEntry, input_modules)
                 module_id: context.module_id_generator++,
                 code: '',
                 map: null,
-                dependencies: [],
-                dynamicDependencies: [],
-                externalDependencies: {},
-                exports: [],
                 imports: [],
+                externalImports: [],
+                dynamicImports: [],
+                externalDynamicImports: [],
+                exports: [],
                 invalidate: true,
                 isEntry,
                 checked: false
@@ -45,58 +45,57 @@ async function parse (context, filepath, current, level, isEntry, input_modules)
         }
 
         if (file.invalidate) {
-            let oldDependencies = file.dependencies;
+            let oldImports = file.imports;
             PluginLifecycle.setCurrentFile(context, filepath);
             let loaded = await PluginLifecycle.load(context, filepath, current);
             let transformed = await PluginLifecycle.transform(context, loaded.code, filepath);
             let { 
-                dependencies, 
                 transpiled, 
-                dynamicDependencies, 
-                externalDependencies, 
-                dynamicExternalDependencies,
                 exports, 
-                imports 
+                imports,
+                externalImports,
+                dynamicImports,
+                externalDynamicImports,
             } = await ImportExportResolver(transformed.code, context, filepath);
 
             file.code = transpiled;
-            file.dependencies = dependencies;
-            file.dynamicDependencies = dynamicDependencies;
-            file.externalDependencies = externalDependencies;
-            file.dynamicExternalDependencies = dynamicExternalDependencies;
-            file.exports = exports;
             file.imports = imports;
+            file.externalImports = externalImports;
+            file.dynamicImports = dynamicImports;
+            file.externalDynamicImports = externalDynamicImports;
+            file.exports = exports;
             file.map = transformed.map;
             file.invalidate = false;
 
-            Object.keys(file.externalDependencies).forEach(exDep => {
-                if (!context.externalFiles[exDep]) {
-                    context.externalFiles[exDep] = [];
+            externalImports.forEach(i => {
+                if (!context.externalFiles[i.source]) {
+                    context.externalFiles[i.source] = [];
                 }
-                
-                context.externalFiles[exDep] = context.externalFiles[exDep].concat(file.externalDependencies[exDep]);
+
+                context.externalFiles[i.source] = context.externalFiles[i.source].concat(i.specifiers.map(i => i.imported));
             });
 
-            file.dynamicExternalDependencies.forEach(exDep => {
-                context.dynamicExternalFiles[exDep] = {};
+            // Used by getModuleInfo
+            file.externalDynamicImports.forEach(exDep => {
+                context.externalDynamicFiles[exDep] = {};
             });
 
 
             // Keeping references in a separate object so it's
             // not tied to whether or not a module successfully loads.
             // Unsuccessful loads can make it difficult to track references.
-            oldDependencies.forEach(dep => {
-                if (context.references[dep]) {
-                    context.references[dep]--;
+            oldImports.forEach(dep => {
+                if (context.references[dep.source]) {
+                    context.references[dep.source]--;
                 }
             });
 
-            file.dependencies.forEach(dep => {
-                if (context.references[dep] === undefined) {
-                    context.references[dep] = 0;
+            file.imports.forEach(dep => {
+                if (context.references[dep.source] === undefined) {
+                    context.references[dep.source] = 0;
                 }
 
-                context.references[dep]++;
+                context.references[dep.source]++;
             });
         }    
         
@@ -109,30 +108,30 @@ async function parse (context, filepath, current, level, isEntry, input_modules)
             file.checked = true;
         }
 
-        let dependencies = file.dependencies;
+        let imports = file.imports;
 
-        for (let i = 0; i < dependencies.length; i++) {
+        for (let i = 0; i < imports.length; i++) {
             try {
-                await parse(context, dependencies[i], filepath, level + 1, false, input_modules);
+                await parse(context, imports[i].source, filepath, level + 1, false, input_modules);
             } catch (e) {
-                throw new ParseError(dependencies[i], e);
+                throw new ParseError(imports[i].source, e);
             } 
         }
 
-        let dynamicDependencies = file.dynamicDependencies;
+        let dynamicImports = file.dynamicImports;
 
-        for (let i = 0; i < dynamicDependencies.length; i++) {
+        for (let i = 0; i < dynamicImports.length; i++) {
             let current_chunk = PluginLifecycle.getCurrentChunk(context);
             try {
                 // TODO: How to detect if dynamic dependency is removed.
-                if (!context.dynamicDependencies[dynamicDependencies[i]]) {
-                    context.dynamicDependencies[dynamicDependencies[i]] = {};
+                if (!context.dynamicDependencies[dynamicImports[i]]) {
+                    context.dynamicDependencies[dynamicImports[i]] = {};
                 }
 
-                PluginLifecycle.setCurrentChunk(context, formatFileName(context, dynamicDependencies[i], context.output.chunkFileNames));
-                await parse(context, dynamicDependencies[i], filepath, 0, false, context.dynamicDependencies[dynamicDependencies[i]]);
+                PluginLifecycle.setCurrentChunk(context, formatFileName(context, dynamicImports[i], context.output.chunkFileNames));
+                await parse(context, dynamicImports[i], filepath, 0, false, context.dynamicDependencies[dynamicImports[i]]);
             } catch (e) {
-                throw new ParseError(dynamicDependencies[i], e);
+                throw new ParseError(dynamicImports[i], e);
             } finally {
                 PluginLifecycle.setCurrentChunk(context, current_chunk);
             }
@@ -143,18 +142,18 @@ async function parse (context, filepath, current, level, isEntry, input_modules)
 }
 
 function createFileFunctionWrapper (context, filepath) {
-    let { code, map, dependencies, dynamicDependencies, imports, syntheticNamedExports } = context.files[filepath];
+    let { code, map, imports, externalImports, dynamicImports, syntheticNamedExports } = context.files[filepath];
 
     // Validate dependencies exist.
-    dependencies.forEach(dep => {
-        if (!context.files[dep]) {
-            throw new Error('File not found: ' + dep);
+    imports.forEach(dep => {
+        if (!context.files[dep.source]) {
+            throw new Error('File not found: ' + dep.source);
         }
     });
 
     // Inject require numbers into module code.
     code = code.replace(/__nollup__dynamic__(\d+)/g, (match, index) => {
-        let dependency = dynamicDependencies[index];
+        let dependency = dynamicImports[index];
 
         if (!context.files[dependency]) {
             throw new Error('File not found: ' + dependency);
@@ -188,24 +187,22 @@ function createFileFunctionWrapper (context, filepath) {
 
     return `
         function (__c__, __r__, __d__, __e__) {
-            ${dependencies.map((d, i) => {
-                return `var _i${i}`;
+            ${imports.map(i => {
+                return `var ${i.importee}; ${i.specifiers.map(s => 'var ' + s.local).join(';')};`
             }).join('; ')}
 
-            ${imports.filter(i => i.local).map(node => {
-                return `var ${node.local}`;
-            }).join('; ')}
-
-            ${imports.filter(i => !i.local).map(node => {
-                return `var ex${node.importee}`;
+            ${externalImports.map(i => {
+                return i.specifiers.map(s => {
+                    if (s.imported === '*')
+                        return `var ${s.local} = ${i.importee};`;
+                    else
+                        return `var ${s.local} = ${i.importee}${s.imported}__;`;
+                }).join(' ');
             }).join('; ')}
 
             __d__(function () {
-                ${imports.filter(i => i.local).map(node => {
-                    return `${node.local} = ${node.importee}()${node.imported === '*'? '' : `.${node.imported}`}`;
-                }).join('; ')}
-                ${imports.filter(i => !i.local).map(node => {
-                    return `ex${node.importee} = ${node.importee}()`;
+                ${imports.map(i => {
+                    return i.specifiers.map(s => `${s.local} = ${i.importee}()${s.imported === '*'? '' : `.${s.imported}`}`).join(';');
                 }).join('; ')}
             }, function (require, module, __nollup__global__) {
                 "use strict";
@@ -219,11 +216,60 @@ function createFileFunctionWrapper (context, filepath) {
                 : ''}
             });
 
-            ${dependencies.map((d, i) => {
-                return `_i${i} = __c__(${context.files[d].module_id}) && function () { return __r__(${context.files[d].module_id}) }`;
+            ${imports.map(i => {
+                return `${i.importee} = __c__(${context.files[i.source].module_id}) && function () { return __r__(${context.files[i.source].module_id}) }`;
             }).join('; ')}
         }   
     `.trim();
+}
+
+function createExternalImports (context) {
+    let output = '';
+    let { format, globals } = context.output;
+
+    output += Object.keys(context.externalFiles).map(file => {
+        let name = file.replace(/[\W]/g, '_');
+        let specifiers = context.externalFiles[file].filter((v, i, t) => t.indexOf(v) === i); // get unique specs
+
+        // Bare external import
+        if (specifiers.length === 0) {
+            if (format === 'esm') 
+                return `import '${file}';`
+            if (format === 'cjs') 
+                return `require('${file}');`
+        }
+
+        return specifiers.map(s => {
+            let iifeName = globals[file] || name;
+
+            if (s === '*') {
+                if (format === 'esm') 
+                    return `import * as __nollup__external__${name}__ from '${file}';`;
+                if (format === 'cjs') 
+                    return `var __nollup__external__${name}__ = require('${file}');`;
+                if (format === 'iife') 
+                    return `var __nollup__external__${name}__ = self.${iifeName};`
+            }
+
+            if (s === 'default') {
+                if (format === 'esm') 
+                    return `import __nollup__external__${name}__default__ from '${file}';`;
+                if (format === 'cjs') 
+                    return `var __nollup__external__${name}__default__ = require('${file}').hasOwnProperty('default')? require('${file}').default : require('${file}');`
+                if (format === 'iife') 
+                    return `var __nollup__external__${name}__default__ = self.${iifeName} && self.${iifeName}.hasOwnProperty('default')? self.${iifeName}.default : self.${iifeName};`
+            }
+
+            if (format === 'esm') 
+                return `import { ${s} as __nollup__external__${name}__${s}__ } from '${file}';`;
+            if (format === 'cjs') 
+                return `var __nollup__external__${name}__${s}__ = require('${file}').${s};`
+            if (format === 'iife') 
+                return `var __nollup__external__${name}__${s}__ = self.${iifeName}.${s};`
+        }).join('\n');
+    }).join('\n');
+
+    return output;
 }
 
 /**
@@ -251,27 +297,7 @@ async function generate (context, input, dynamicFileName) {
         return [
                 banner,
                 intro,
-                context.output && context.output.format === 'esm'? Object.keys(context.externalFiles).map(dep => {
-                    let output = '';
-                    let depName = dep.replace(/[\W]/g, '_');
-                    let specs = context.externalFiles[dep];
-                    if (specs.indexOf('*') > -1) {
-                        output += `import * as __nollup__external__${depName}__ from '${dep}';\n`;
-                    }
-
-                    if (specs.indexOf('default') > -1) {
-                        output += `import __nollup__external__${depName}__default__ from '${dep}';\n`;
-                    }
-
-                    let named = specs.filter((v, i, t) => t.indexOf(v) === i && v !== '*' && v !== 'default');
-                    if (named.length > 0) {
-                        output += 'import { ' + named.map(i => {
-                            return `${i} as __nollup__external__${depName}__${i}__`
-                        }).join(', ') + ' } from \'' + dep + '\';\n';
-                    }
-
-                    return output;
-                }).join('\n') : '',
+                createExternalImports(context),
                 `
         ${(context.files[input.file].exports.length > 0 && context.output.format === 'esm')? 'var __nollup_entry_exports = ' : ''}(function (modules, __nollup__global__) {
             let instances = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ let AcornParser = require('./impl/AcornParser');
 let ParseError = require('./impl/ParseError');
 let { formatFileName, resolvePath } = require('./impl/utils');
 
+const CHECKED_FILES = Symbol('CHECKED_FILES')
+
 /**
  * Loads target module.
  *
@@ -20,6 +22,10 @@ let { formatFileName, resolvePath } = require('./impl/utils');
 async function parse (context, filepath, current, level, isEntry, input_modules) {
     if (level >= 255) {
         throw new Error('Maximum parse call stack exceeded.');
+    }
+
+    if (!input_modules[CHECKED_FILES]) {
+      input_modules[CHECKED_FILES] = {}
     }
 
     // If false, module is not included.
@@ -38,7 +44,6 @@ async function parse (context, filepath, current, level, isEntry, input_modules)
                 exports: [],
                 invalidate: true,
                 isEntry,
-                checked: false
             };
 
             context.files[filepath] = file;
@@ -102,10 +107,10 @@ async function parse (context, filepath, current, level, isEntry, input_modules)
         input_modules[filepath] = true;
 
         // Circular Dependency Check
-        if (file.checked) {
+        if (input_modules[CHECKED_FILES][file.module_id]) {
             return;
         } else {
-            file.checked = true;
+            input_modules[CHECKED_FILES][file.module_id] = true;
         }
 
         let imports = file.imports;
@@ -129,7 +134,7 @@ async function parse (context, filepath, current, level, isEntry, input_modules)
                 }
 
                 PluginLifecycle.setCurrentChunk(context, formatFileName(context, dynamicImports[i], context.output.chunkFileNames));
-                await parse(context, dynamicImports[i], filepath, 0, false, context.dynamicDependencies[dynamicImports[i]]);
+                await parse(context, dynamicImports[i], filepath, level + 1, false, context.dynamicDependencies[dynamicImports[i]]);
             } catch (e) {
                 throw new ParseError(dynamicImports[i], e);
             } finally {
@@ -523,10 +528,6 @@ async function bundle (context) {
     let invalidated = Object.keys(context.files).filter(filepath => context.files[filepath].invalidate);
 
     context.dynamicDependencies = {};
-
-    Object.keys(context.files).forEach(key => {
-        context.files[key].checked = false;
-    });
 
     let buildFinish = async (arg) => {
         for (let i = 0; i < context.plugins.length; i++) {

--- a/test/cases/api/hooks.js
+++ b/test/cases/api/hooks.js
@@ -603,7 +603,7 @@ describe ('API: Plugin Hooks', () => {
             });
 
             let { output } = await bundle.generate({ format: 'esm' });
-            expect(output[0].code.indexOf('import "haha"') > -1).to.be.true;
+            expect(output[0].code.indexOf('import \'haha\';') > -1).to.be.true;
             expect(output[0].code.indexOf('module.exports.default = 123') === -1).to.be.true;
             fs.reset();
         });

--- a/test/cases/misc.js
+++ b/test/cases/misc.js
@@ -108,4 +108,13 @@ describe ('Misc', () => {
         expect(output[0].code.indexOf('world') > -1).to.be.true;
         expect(Object.keys(myplugin).length).to.equal(1);
     });
+
+
+    it ('should not break imports that are on the same line');
+
+    it ('should not misalign sourcemaps when using multi-line imports');
+
+    it ('should not break exports that are on the same line');
+
+    it ('should not misalign sourcemaps when using multi-line export from');
 });


### PR DESCRIPTION
fixes #85

A better fix than just commenting out the `if (file.checked)` test.

It works in my simple repro, and it also works with my big complicated (dynamic imports wise) project.

Apparently it also fixes a infinite parse loop I kept having (randomly).

I based on the SourceMap branch, since I guess it's the "stable" tip.