### PR TITLE
abstract dev server into separate file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -8,14 +8,8 @@ if (!process.env.NOLLUP) {
     process.env.NOLLUP = 'true';
 }
 
-let fs = require('fs');
 let path = require('path');
-let express = require('express');
-let fallback = require('express-history-api-fallback');
-let proxy = require('express-http-proxy');
-let nollupDevServer = require('./dev-middleware');
-let ConfigLoader = require('./impl/ConfigLoader');
-let app = express();
+const devServer = require('./dev-server')
 
 let options = {
     config: path.normalize(process.cwd() + '/rollup.config.js'),
@@ -98,54 +92,7 @@ for (let i = 0; i < process.argv.length; i++) {
     }
 }
 
-(async function () {
-    if (fs.existsSync('.nolluprc')) {
-        options = Object.assign({}, options, JSON.parse(fs.readFileSync('.nolluprc')));
-    } else if (fs.existsSync('.nolluprc.js')) {
-        options = Object.assign({}, options, require(path.resolve(process.cwd(), './.nolluprc.js')));
-    }
-
-    if (options.before) {
-        options.before(app);
-    }
-
-    let config = await ConfigLoader.load(options.config);
-    app.use(nollupDevServer(app, config, {
-        hot: options.hot,
-        verbose: options.verbose,
-        hmrHost: options.hmrHost,
-        contentBase: options.contentBase,
-        publicPath: options.publicPath
-    }));
-
-    if (options.proxy) {
-        Object.keys(options.proxy).forEach(route => {
-            let target = options.proxy[route];
-            app.use(route, proxy(target, {
-                proxyReqPathResolver: req => {
-                    let req_path = require('url').parse(req.url).path;
-                    return route + (req_path === '/'? '' : req_path);
-                }
-            }));
-        });
-    }
-
-    app.use(express.static(options.contentBase));
-
-    if (options.after) {
-        options.after(app);
-    }
-
-    if (options.historyApiFallback) {
-        app.use(fallback('index.html', { root: options.contentBase }));
-    }
-
-    app.listen(options.port);
-
-    console.log(`Listening on http://localhost:${options.port}`);
-})();
-
-
+devServer(options)
 
 // Needed for posix systems when used with npm-run-all.
 process.on('SIGTERM', () => {

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -1,0 +1,57 @@
+let fs = require('fs');
+let path = require('path');
+let express = require('express');
+let fallback = require('express-history-api-fallback');
+let proxy = require('express-http-proxy');
+let nollupDevServer = require('./dev-middleware');
+let ConfigLoader = require('./impl/ConfigLoader');
+let app = express();
+
+async function devServer(options) {
+    if (fs.existsSync('.nolluprc')) {
+        options = Object.assign({}, options, JSON.parse(fs.readFileSync('.nolluprc')));
+    } else if (fs.existsSync('.nolluprc.js')) {
+        options = Object.assign({}, options, require(path.resolve(process.cwd(), './.nolluprc.js')));
+    }
+
+    if (options.before) {
+        options.before(app);
+    }
+
+    let config = await ConfigLoader.load(options.config);
+    app.use(nollupDevServer(app, config, {
+        hot: options.hot,
+        verbose: options.verbose,
+        hmrHost: options.hmrHost,
+        contentBase: options.contentBase,
+        publicPath: options.publicPath
+    }));
+
+    if (options.proxy) {
+        Object.keys(options.proxy).forEach(route => {
+            let target = options.proxy[route];
+            app.use(route, proxy(target, {
+                proxyReqPathResolver: req => {
+                    let req_path = require('url').parse(req.url).path;
+                    return route + (req_path === '/' ? '' : req_path);
+                }
+            }));
+        });
+    }
+
+    app.use(express.static(options.contentBase));
+
+    if (options.after) {
+        options.after(app);
+    }
+
+    if (options.historyApiFallback) {
+        app.use(fallback('index.html', { root: options.contentBase }));
+    }
+
+    app.listen(options.port);
+
+    console.log(`[Nollup] Listening on http://localhost:${options.port}`);
+}
+
+module.exports = devServer


### PR DESCRIPTION
Didn't get the included tests to start, but tested it against my own project, which worked fine.

I updated `Listening on...` to `[Nollup] Listening on...` to discern it from other running servers. Other than that and the abstraction, there are no changes to the original code.

I'm not sure how to compare changes across files, so I copy pasted a screenshot from text-compare.com.

![image](https://user-images.githubusercontent.com/4153004/85020466-ad4a4280-b170-11ea-9698-e623f3959399.png)
