### PR TITLE
use historyApiFallback as fallback if string

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -46,7 +46,10 @@ async function devServer(options) {
     }
 
     if (options.historyApiFallback) {
-        app.use(fallback('index.html', { root: options.contentBase }));
+        const entryPoint = typeof options.historyApiFallback === 'string'
+            ? options.historyApiFallback
+            : 'index.html'
+        app.use(fallback(entryPoint, { root: options.contentBase }));
     }
 
     app.listen(options.port);


### PR DESCRIPTION
It's becoming increasingly common for frameworks to use static exports. This makes it unsafe to use `index.html` as an entrypoint, as it will be overwritten by the export. To handle this, the entrypoint can be written to an alternative file. Ie. Routify writes the entrypoint to `__app.html`.

The PR uses the `historyApiFallback` as the entry point. If `historyApiFallback` is truthy, but not a string, the default `index.html` will be used instead.