### PR TITLE
Add repository and homepage field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "description": "Rollup-compatible bundler for development.",
   "version": "0.12.0",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PepsRyuu/nollup.git"
+  },
+  "homepage": "https://github.com/PepsRyuu/nollup",
   "scripts": {
     "test": "mocha-istanbul-ui \"test/cases/**/*.js\" --instrument --console --once",
     "test:ui": "mocha-istanbul-ui \"test/cases/**/*.js\" --instrument --watch"


### PR DESCRIPTION
As in description, see #103 
People won't have to search github/ gitlab/ others for official repository.

Hopefully this will also fix relative links in README.md and docs on npmjs.

AFAIK npmjs will refresh <https://www.npmjs.com/package/nollup> when new version is tagged.