### PR TITLE
Log error instead of throwing

### DIFF
--- a/lib/impl/PluginContext.js
+++ b/lib/impl/PluginContext.js
@@ -146,7 +146,7 @@ module.exports = {
             },
 
             error (e) {
-                throw e;
+                console.error(e);
             },
 
             emitAsset (name, source) {


### PR DESCRIPTION
Not sure if there is any specific intention of throwing the error here instead of logging?

When using the [typescript](https://github.com/rollup/plugins/tree/master/packages/typescript) plugin, nollup just logs "undefined" when typescript emits errors – without any feedback that rollup has. Might as well just log it out to the console and skip throwing, since that also exits the process – which we dont want for ts atleast. 
Could also consider replicate/copy the logging behaviour of rollup for the plugin context to align them even more :)