### PR TITLE
Use message if stack is not provided

### DIFF
--- a/lib/dev-middleware.js
+++ b/lib/dev-middleware.js
@@ -107,7 +107,7 @@ module.exports = function (app, config, options) {
             file_listeners = [];
             console.log('\x1b[32m%s\x1b[0m', `[Nollup] Compiled in ${compilation_time}ms.`);
         } catch (e) {
-            console.log('\x1b[91m%s\x1b[0m', e.stack);
+            console.log('\x1b[91m%s\x1b[0m', e.stack || e.message);
         }
     }
 


### PR DESCRIPTION
You are totally right! https://github.com/PepsRyuu/nollup/pull/117#issuecomment-665645349

The plugin also provides a more detailed `frame` btw.
```
{
  pluginCode: 'TS2322',
  message: "@rollup/plugin-typescript TS2322: Type '{}' is not assignable to type 'string'.",
  loc: {
    column: 15,
    line: 77,
    file: '...'
  },
  frame: '\n' +
    '\u001b[7m77\u001b[0m         const unlockedRequirements: string = Object.entries(data).reduce(\n' +
    '\u001b[7m  \u001b[0m \u001b[91m              ~~~~~~~~~~~~~~~~~~~~\u001b[0m\n'
}
```
