### PR TITLE
Add watchChange support

### DIFF
--- a/lib/impl/NollupContext.js
+++ b/lib/impl/NollupContext.js
@@ -1,5 +1,6 @@
 let AcornParser = require('./AcornParser');
 let PluginContext = require('./PluginContext');
+let PluginLifecycle = require('./PluginLifecycle');
 let path = require('path');
 let { resolvePath, getNameFromFileName } = require('./utils');
 
@@ -126,10 +127,12 @@ module.exports = {
         filePath = resolvePath(filePath, process.cwd() + '/__entry__');
         if (context.files[filePath]) {
             context.files[filePath].invalidate = true;
+            PluginLifecycle.hooks.watchChange(context, filePath);
         }
 
          if (context.watchFiles[filePath]) {
             context.files[context.watchFiles[filePath]].invalidate = true;
+            PluginLifecycle.hooks.watchChange(context, filePath);
         }
     },
 

--- a/lib/impl/PluginContext.js
+++ b/lib/impl/PluginContext.js
@@ -8,7 +8,8 @@ function getReferenceId () {
 
 module.exports = {
     meta: {
-        rollupVersion: '2.0'
+        rollupVersion: '2.0',
+        watchMode: true
     },
 
     create (context, plugin) {

--- a/lib/impl/PluginLifecycle.js
+++ b/lib/impl/PluginLifecycle.js
@@ -85,6 +85,11 @@ function callSyncFirstHook (context, hook, args) {
 
 function callSyncSequentialHook () {
     // all plugins that implement this hook will run, passing data onwards
+    let { plugins, pluginsContext } = context;
+
+    for (let i = 0; i < plugins.length; i++) {
+        _callSyncHook(pluginsContext[i], plugins[i], hook, args);
+    };
 }
 
 module.exports = {
@@ -210,6 +215,10 @@ module.exports = {
                 code: hr.code,
                 map: map
             };
+        },
+
+        watchChange (context, filePath) {
+            callSyncSequentialHook(context, 'watchChange', [filePath]);
         },
 
         async buildEnd (context, error) {            

--- a/lib/impl/PluginLifecycle.js
+++ b/lib/impl/PluginLifecycle.js
@@ -83,7 +83,7 @@ function callSyncFirstHook (context, hook, args) {
     } 
 }
 
-function callSyncSequentialHook () {
+function callSyncSequentialHook (context, hook, args) {
     // all plugins that implement this hook will run, passing data onwards
     let { plugins, pluginsContext } = context;
 

--- a/test/cases/api/hooks.js
+++ b/test/cases/api/hooks.js
@@ -2607,6 +2607,39 @@ describe ('API: Plugin Hooks', () => {
     });
 
     describe ('watchChange', () => {
-        it ('should receive id of changed module');
+        it ('should not trigger initially', async () => {
+            fs.stub('./src/main.js', () => 'export default 123');
+            let watchChangeCnt = 0;
+
+            let bundle = await nollup({
+                input: './src/main.js',
+                plugins: [{
+                    watchChange (id) {
+                        watchChangeCnt++;
+                    }
+                }]
+            });
+            output = await bundle.generate();
+
+            expect(watchChangeCnt).to.be.equal(0)
+        });
+        it ('should trigger on invalidate', async () => {
+            fs.stub('./src/main.js', () => 'export default 123');
+            let watchChangeCnt = 0;
+
+            let bundle = await nollup({
+                input: './src/main.js',
+                plugins: [{
+                    watchChange (id) {
+                        watchChangeCnt++;
+                    }
+                }]
+            });
+            output = await bundle.generate()
+            bundle.invalidate("./src/main.js")
+
+            output = await bundle.generate();
+            expect(watchChangeCnt).to.be.equal(1)
+        });
     });
 });


### PR DESCRIPTION
Nollup does not use the watchChange hook that the typescript rollup plugin uses to sync ts compiling, this means nollup finishes compiling too early before the ts changes propagates. The plugin also requires the rollup watchMode meta property to not close the ts program, so I guess we could just set that to true?

I just put watchChange hook a place it made sense, let me know if you have any other suggestions!