### PR TITLE
HTTPS fixes

### DIFF
--- a/lib/dev-middleware.js
+++ b/lib/dev-middleware.js
@@ -8,7 +8,7 @@ let mime = require('mime-types');
 let path = require('path');
 let { createFilter } = require('@rollup/pluginutils');
 
-module.exports = function (app, server, config, options) {
+module.exports = function (app, config, options, server) {
     expressws(app, server);
     let bundles = [];
     let isBundling = true;

--- a/lib/dev-middleware.js
+++ b/lib/dev-middleware.js
@@ -8,8 +8,8 @@ let mime = require('mime-types');
 let path = require('path');
 let { createFilter } = require('@rollup/pluginutils');
 
-module.exports = function (app, config, options) {
-    expressws(app);
+module.exports = function (app, server, config, options) {
+    expressws(app, server);
     let bundles = [];
     let isBundling = true;
     let files = {};

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -43,14 +43,14 @@ async function devServer(options) {
     }
 
     let config = await ConfigLoader.load(options.config);
-    app.use(nollupDevMiddleware(app, server, config, {
+    app.use(nollupDevMiddleware(app, config, {
         hot: options.hot,
         verbose: options.verbose,
         headers: options.headers,
         hmrHost: options.hmrHost,
         contentBase: options.contentBase,
         publicPath: options.publicPath
-    }));
+    }, server));
 
     if (options.proxy) {
         Object.keys(options.proxy).forEach(route => {

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -20,6 +20,18 @@ async function devServer(options) {
         options.before(app);
     }
 
+    let server
+    if (options.https) {
+        if (!(options.key && options.cert)) {
+            throw new Error('Usage of https requires cert and key to be set.')
+        }
+        const key = fs.readFileSync(options.key)
+        const cert = fs.readFileSync(options.cert)
+        server = https.createServer({ key, cert }, app)
+    } else {
+        server = http.createServer(app)
+    }
+
     if (options.headers) {
         app.all('*', (req, res, next) => {
             for (let prop in options.headers) {
@@ -31,7 +43,7 @@ async function devServer(options) {
     }
 
     let config = await ConfigLoader.load(options.config);
-    app.use(nollupDevMiddleware(app, config, {
+    app.use(nollupDevMiddleware(app, server, config, {
         hot: options.hot,
         verbose: options.verbose,
         headers: options.headers,
@@ -63,17 +75,7 @@ async function devServer(options) {
         app.use(fallback(entryPoint, { root: options.contentBase }));
     }
 
-    if (options.https) {
-        if (!(options.key && options.cert)) {
-            throw new Error('Usage of https requires cert and key to be set.');
-        }
-
-        const key = fs.readFileSync(options.key);
-        const cert = fs.readFileSync(options.cert);
-        https.createServer({ key, cert }, app).listen(options.port);
-    } else {
-        app.listen(options.port);
-    }
+    server.listen(options.port);
 
     console.log(`[Nollup] Listening on ${options.https ? 'https' : 'http'}://localhost:${options.port}`);
 }


### PR DESCRIPTION
Just try to use certificate like this (from package.json of https://github.com/rixo/rollup-plugin-svelte-hot package):
`nollup -c --hot --https --key keys/localhost.key --cert keys/localhost.cert --port 5000 --content-base ./public`

I fixed this, so no more errors when loading or changing the page.