### PR TITLE
Line Breaks fix

### DIFF
--- a/lib/impl/CodeGenerator.js
+++ b/lib/impl/CodeGenerator.js
@@ -19,7 +19,7 @@ function generateFile (context, filePath) {
     code = code
                .replace(/\\/g, '\\\\')
                .replace(/'/g, '\\\'')
-               .replace(/(\r)?\n/g, '\\n\\\n')
+               .replace(/(\r\n|[\n\r])/g, '\\n\\\n')
 
 
     // Transform the source path so that they display well in the browser debugger.


### PR DESCRIPTION
If you use \r\n instead of \n in main.js, then one extra \r appears in the generated code. The buggy code may be somewhere else, but this fix is simple and works.