### PR TITLE
only use ConfigLoader when config is string

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -42,7 +42,7 @@ async function devServer(options) {
         });
     }
 
-    let config = await ConfigLoader.load(options.config);
+    let config = typeof options.config === 'string' ? await ConfigLoader.load(options.config) : options.config;
     let nollup = NollupDevMiddleware(app, config, {
         hot: options.hot,
         verbose: options.verbose,


### PR DESCRIPTION
According to the link below `options.config` is an object, but `dev-server.js` treats it as a string.

This PR only parses `config` through `ConfigLoader` if `config` is a string.

https://github.com/PepsRyuu/nollup/blob/master/docs/dev-server.md