### PR TITLE
Add support for config.rollup.mjs/ESM configs

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,10 +9,21 @@ if (!process.env.NOLLUP) {
 }
 
 let path = require('path');
+const fs = require('fs');
 const devServer = require('./dev-server')
 
+// from rollup/cli/run/getConfigPath
+function findConfigFileNameInCwd() {
+	const filesInWorkingDir = new Set(fs.readdirSync(process.cwd()));
+	for (const extension of ['mjs', 'cjs']) {
+		const fileName = `rollup.config.${extension}`;
+		if (filesInWorkingDir.has(fileName)) return fileName;
+	}
+	return `rollup.config.js`;
+}
+
 let options = {
-    config: path.normalize(process.cwd() + '/rollup.config.js'),
+    config: path.normalize(process.cwd() + '/' + findConfigFileNameInCwd()),
     contentBase: './',
     historyApiFallback: false,
     hot: false,

--- a/lib/impl/ConfigLoader.js
+++ b/lib/impl/ConfigLoader.js
@@ -1,8 +1,27 @@
 // @ts-check
 let nollup = require('../index');
 let path = require('path');
+let url = require('url');
 
 module.exports = class ConfigLoader {
+    /**
+     * Uses compiler to compile rollup.config.js
+     * or dynamic import to directly load rollup.config.mjs
+     * 
+     * @param {string} filepath
+     * @return {Promise<object>}
+     */
+    static async load(filepath) {
+        let config = filepath.endsWith('.mjs') ?
+            await ConfigLoader.loadESM(filepath) :
+            await ConfigLoader.loadCJS(filepath);
+
+        // When function, resolve
+        return (typeof config === 'function')
+            ? config()
+            : config;
+    }
+
     /**
      * Uses compiler to compile rollup.config.js file.
      * This allows config file to use ESM, but compiles to CJS
@@ -11,7 +30,7 @@ module.exports = class ConfigLoader {
      * @param {string} filepath
      * @return {Promise<object>}
      */
-    static async load (filepath) {
+    static async loadCJS(filepath) {
         // If it isn't relative, it's probably a NodeJS import
         // so mark it as external so the require call persists.
         let bundle = await nollup({
@@ -43,9 +62,20 @@ module.exports = class ConfigLoader {
         config = config.default || config;
         require.extensions['.js'] = defaultLoader;
 
-        // When function, resolve
-        return (typeof config === 'function')
-            ? await config()
-            : config;
+        return config;
+    }
+
+    /**
+     * Directly imports rollup.config.mjs
+     *
+     * @param {string} filepath
+     * @return {Promise<object>}
+     */
+    static async loadESM(filepath) {
+        if(!filepath.startsWith('/') && !filepath.startsWith('./') && !filepath.startsWith('file://')) {
+            // import needs a URL, not a path. (mainly for Windows)
+            filepath = url.pathToFileURL(filepath).toString();
+        }
+        return (await import(filepath)).default;
     }
 };


### PR DESCRIPTION
Rollup supports mjs/cjs/js extensions for the config: 
```
# if you do not pass a file name, Rollup will try to load
# configuration files in the following order:
# rollup.config.mjs -> rollup.config.cjs -> rollup.config.js
```

So this adds support for that.

The change in cli.js searches for mjs/cjs with a fallback to .js (code copied from rollup)
The change in impl/ConfigLoader.js uses import when a file ends with mjs, instead of compiling and requiring.
A little extra work is needed for importing the mjs file on windows due to it needing urls and not paths: nodejs/node#34765

I would add tests but... it doesn't seem like the cli is tested. I could add an example project instead.