### PR TITLE
Generalize "proxy" options to handle globs.

### DIFF
--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -67,8 +67,7 @@ async function devServer(options) {
             
             app.use(route, proxy(host, {
                 proxyReqPathResolver: req => {
-                    let req_path = require('url').parse(req.url).path;
-                    return route + (req_path === '/' ? '' : req_path);
+                    return require('url').parse(req.originalUrl).path;
                 },
                 ...routeOptions
             }));


### PR DESCRIPTION
While globs were always handled, the proxied URL was incorrect, because the proxy key (e.g. `/foo/*/bar`) was concatenated with the rest of the path.

Example:
Proxy key: `/foo/*/bar`
Full request url: `/foo/xxx/bar/hello`
Gets rewritten to: `/foo/*/bar/hello`

After this change, it will get rewritten to: `/foo/xxx/bar/hello`