### PR TITLE
Replace express-ws with ws

### DIFF
--- a/lib/dev-middleware.js
+++ b/lib/dev-middleware.js
@@ -1,6 +1,6 @@
 let nollup = require('./index');
 let chokidar = require('chokidar');
-let expressws = require('express-ws');
+let WebSocket = require('ws');
 let fs = require('fs');
 let url = require('url');
 let hmr = require('./plugin-hmr');
@@ -9,7 +9,6 @@ let path = require('path');
 let { createFilter } = require('@rollup/pluginutils');
 
 module.exports = function (app, config, options, server) {
-    expressws(app, server);
     let bundles = [];
     let isBundling = true;
     let files = {};
@@ -45,15 +44,20 @@ module.exports = function (app, config, options, server) {
 
             sockets[i] = [];
 
-            app.ws('/__hmr' + (i || ''), (ws, req) => {
-                sockets[i].push(ws);
+            server.on('upgrade', (request, socket, head) => {
+                if (request.url === '/__hmr' + (i || '')) {
+                    const wsServer = new WebSocket.Server({ noServer: true });
+                    wsServer.handleUpgrade(request, socket, head, (ws) => {
+                        sockets[i].push(ws);
 
-                // greeting -- see: https://github.com/PepsRyuu/nollup/issues/35
-                ws.send(JSON.stringify({ greeting: true }))
+                        // greeting -- see: https://github.com/PepsRyuu/nollup/issues/35
+                        ws.send(JSON.stringify({ greeting: true }));
 
-                ws.on('close', () => {
-                    sockets[i].splice(sockets[i].indexOf(ws), 1);
-                });
+                        ws.on('close', () => {
+                            sockets[i].splice(sockets[i].indexOf(ws), 1);
+                        });
+                    });
+                }
             });
         });
     }

--- a/lib/dev-server.js
+++ b/lib/dev-server.js
@@ -34,10 +34,6 @@ async function devServer(options) {
         options = await loadRc(options, '.nolluprc.js');
     }
 
-    if (options.before) {
-        options.before(app);
-    }
-
     let server
     if (options.https) {
         if (!(options.key && options.cert)) {
@@ -48,6 +44,10 @@ async function devServer(options) {
         server = https.createServer({ key, cert }, app)
     } else {
         server = http.createServer(app)
+    }
+
+    if (options.before) {
+        options.before(app, server);
     }
 
     if (options.headers) {
@@ -96,10 +96,6 @@ async function devServer(options) {
         index: options.historyApiFallback? false : 'index.html'
     }));
 
-    if (options.after) {
-        options.after(app);
-    }
-
     if (options.historyApiFallback) {
         let entryPoint = typeof options.historyApiFallback === 'string'? options.historyApiFallback : 'index.html';
 
@@ -118,6 +114,10 @@ async function devServer(options) {
         });
 
         app.use(fallback(entryPoint, { root: options.contentBase }));
+    }
+
+    if (options.after) {
+        options.after(app, server);
     }
 
     server.listen(options.port, options.host || 'localhost');

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "express": "^4.16.3",
     "express-history-api-fallback": "^2.2.1",
     "express-http-proxy": "^1.5.1",
-    "express-ws": "^4.0.0",
     "magic-string": "^0.25.7",
     "mime-types": "^2.1.29",
     "source-map": "^0.5.6",
-    "source-map-fast": "npm:source-map@0.7.3"
+    "source-map-fast": "npm:source-map@0.7.3",
+    "ws": "^7.4.6"
   },
   "devDependencies": {
     "chai": "^4.3.4",


### PR DESCRIPTION
I need to proxy websocket connection to my backend. I was unable to use `express-http-proxy` or `http-proxy` along with `express-ws`. There was an error during the upgrade handshake. Handling the upgrade directly with `ws` fixes the issue. I also added the `server` object to the `before` and `after` since I needed it to handle the WS upgrade.

Thanks for reviewing!