### PR TITLE
Update packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,25 +18,25 @@
     "nollup": "./lib/cli.js"
   },
   "dependencies": {
-    "@rollup/pluginutils": "^3.0.8",
-    "acorn": "^8.1.0",
-    "chokidar": "^3.5.1",
-    "convert-source-map": "^1.5.1",
-    "express": "^4.16.3",
+    "@rollup/pluginutils": "^3.1.0",
+    "acorn": "^8.8.0",
+    "chokidar": "^3.5.3",
+    "convert-source-map": "^1.8.0",
+    "express": "^4.18.1",
     "express-history-api-fallback": "^2.2.1",
-    "express-http-proxy": "^1.5.1",
-    "magic-string": "^0.25.7",
-    "mime-types": "^2.1.29",
-    "source-map": "^0.5.6",
-    "source-map-fast": "npm:source-map@0.7.3",
-    "ws": "^7.5.3"
+    "express-http-proxy": "^1.6.3",
+    "magic-string": "^0.26.2",
+    "mime-types": "^2.1.35",
+    "source-map": "^0.7.4",
+    "source-map-fast": "npm:source-map@0.7.4",
+    "ws": "^7.5.9"
   },
   "devDependencies": {
-    "chai": "^4.3.4",
-    "mocha": "^8.3.0",
+    "chai": "^4.3.6",
+    "mocha": "^8.4.0",
     "mocha-istanbul-ui": "^0.4.1",
-    "proxyquire": "^2.0.1",
+    "proxyquire": "^2.1.3",
     "requirejs": "^2.3.6",
-    "rollup": "^2.77.0"
+    "rollup": "^2.78.1"
   }
 }


### PR DESCRIPTION
Updating nollups packages to the latest, which also fixes the following issue in the `source-map` package (spotted while testing the react template):

https://github.com/mozilla/source-map/issues/432

The updates were generated automatically with the [npm-check-updates](https://www.npmjs.com/package/npm-check-updates) package, excluding major package updates, with the command:

`ncu -u --target minor`
