### PR TITLE
meta rollupVersion updated to from 2.70 to 2.78

### DIFF
--- a/lib/impl/PluginMeta.js
+++ b/lib/impl/PluginMeta.js
@@ -1,5 +1,5 @@
 // @ts-check
 module.exports = {
-    rollupVersion: '2.70',
+    rollupVersion: '2.78',
     watchMode: true
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "magic-string": "^0.25.7",
     "mime-types": "^2.1.29",
     "source-map": "^0.5.6",
-    "source-map-fast": "npm:source-map@0.7.3",
+    "source-map-fast": "npm:source-map@^0.7.4",
     "ws": "^7.5.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "magic-string": "^0.25.7",
     "mime-types": "^2.1.29",
     "source-map": "^0.5.6",
-    "source-map-fast": "npm:source-map@^0.8.0-beta.0",
+    "source-map-fast": "github:Sanshain/source-map#v0.7.x",
     "ws": "^7.5.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "magic-string": "^0.25.7",
     "mime-types": "^2.1.29",
     "source-map": "^0.5.6",
-    "source-map-fast": "npm:source-map@^0.7.4",
+    "source-map-fast": "npm:source-map@^0.8.0-beta.0",
     "ws": "^7.5.3"
   },
   "devDependencies": {

--- a/test/cases/api/context.js
+++ b/test/cases/api/context.js
@@ -1,3 +1,5 @@
+//@ts-check
+
 let { nollup, fs, expect, rollup } = require('../../nollup');
 let path = require('path');
 let MagicString = require('magic-string');
@@ -1320,7 +1322,8 @@ describe ('API: Plugin Context', () => {
         });
     });
 
-    describe ('meta', () => {
+    describe('meta', () => {
+        
         it ('should have rollupVersion', async () => {
             fs.stub('./src/main.js', () => 'export default 123');
 
@@ -1328,7 +1331,7 @@ describe ('API: Plugin Context', () => {
                 input: './src/main.js',
                 plugins: [{
                     transform () {
-                        expect(this.meta.rollupVersion).to.equal('2.70');
+                        expect(this.meta.rollupVersion).to.equal('2.78');
                     }
                 }]
             });

--- a/test/cases/api/hooks.js
+++ b/test/cases/api/hooks.js
@@ -1703,7 +1703,7 @@ describe ('API: Plugin Hooks', () => {
                 input: './src/main.js',
                 plugins: [{
                     options (opts) {
-                        expect(this.meta.rollupVersion).to.equal('2.70');
+                        expect(this.meta.rollupVersion).to.equal('2.78');
                         passed = true;
                     }
                 }]


### PR DESCRIPTION
That's a widespread problem with compability nollup and actual versions of official rollup plugin (@rollup/plugin-node-resolve, @rollup/plugin-commonjs etc), for example with node-resolve v 15.2.3:

> Error: Insufficient rollup version: "@rollup/plugin-node-resolve" requires at least rollup@2.78.0 but found rollup@2.70.

 Most of them require at least 2.78.0 rollup version. I figered out that to solve this problem, it is quite to update version `rollupVersion` within `lib/impl/PluginMeta.js` file. After the fix nollup continues to interact perfectly with the newest at the moment versions of the plugins

